### PR TITLE
Fixed import namespace for SciPy

### DIFF
--- a/models/dgi.py
+++ b/models/dgi.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from layers import GCN, AvgReadout, Discriminator
+from ..layers import GCN, AvgReadout, Discriminator
 
 class DGI(nn.Module):
     def __init__(self, n_in, n_h, activation):

--- a/utils/process.py
+++ b/utils/process.py
@@ -2,7 +2,7 @@ import numpy as np
 import pickle as pkl
 import networkx as nx
 import scipy.sparse as sp
-from scipy.sparse.linalg.eigen.arpack import eigsh
+from scipy.sparse.linalg import eigsh
 import sys
 import torch
 import torch.nn as nn


### PR DESCRIPTION
SciPy's error message was: 
```
Please use `eigsh` from the `scipy.sparse.linalg` namespace, the `scipy.sparse.linalg.eigen` namespace is deprecated.
```